### PR TITLE
feat(sleep): add autosleep subcommands and manager

### DIFF
--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/Main.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/Main.java
@@ -14,6 +14,7 @@ import io.github.hello09x.fakeplayer.core.listener.FakeplayerLifecycleListener;
 import io.github.hello09x.fakeplayer.core.listener.FakeplayerListener;
 import io.github.hello09x.fakeplayer.core.listener.PlayerListener;
 import io.github.hello09x.fakeplayer.core.manager.FakeplayerAutofishManager;
+import io.github.hello09x.fakeplayer.core.manager.FakeplayerAutosleepManager;
 import io.github.hello09x.fakeplayer.core.manager.FakeplayerReplenishManager;
 import io.github.hello09x.fakeplayer.core.manager.WildFakeplayerManager;
 import io.github.hello09x.fakeplayer.core.manager.invsee.InvseeManager;
@@ -68,9 +69,13 @@ public final class Main extends JavaPlugin {
             manager.registerEvents(injector.getInstance(FakeplayerLifecycleListener.class), this);
             manager.registerEvents(injector.getInstance(FakeplayerListener.class), this);
             manager.registerEvents(injector.getInstance(FakeplayerAutofishManager.class), this);
+            manager.registerEvents(injector.getInstance(FakeplayerAutosleepManager.class), this);
             manager.registerEvents(injector.getInstance(FakeplayerReplenishManager.class), this);
             manager.registerEvents(injector.getInstance(InvseeManager.class), this);
         }
+
+        // Start autosleep scheduler
+        injector.getInstance(FakeplayerAutosleepManager.class).startScheduler();
 
         {
             var placeholderExpansion = injector.getInstance(FakeplayerPlaceholderExpansion.class);

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/CommandRegistry.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/CommandRegistry.java
@@ -408,6 +408,20 @@ public class CommandRegistry {
                                 .withShortDescription("fakeplayer.command.sleep.description")
                                 .withPermission(Permission.sleep)
                                 .withRequirement(CommandSupports::hasFakeplayer)
+                                .withSubcommands(
+                                        command("once")
+                                                .withShortDescription("fakeplayer.command.sleep.once")
+                                                .withOptionalArguments(fakeplayer("name", p -> !p.isSleeping()))
+                                                .executes(sleepCommand::sleepOnce),
+                                        command("auto")
+                                                .withShortDescription("fakeplayer.command.sleep.auto")
+                                                .withOptionalArguments(fakeplayer("name"))
+                                                .executes(sleepCommand::sleepAuto),
+                                        command("stop")
+                                                .withShortDescription("fakeplayer.command.sleep.stop")
+                                                .withOptionalArguments(fakeplayer("name"))
+                                                .executes(sleepCommand::sleepStop)
+                                )
                                 .withOptionalArguments(fakeplayer("name", p -> !p.isSleeping()))
                                 .executes(sleepCommand::sleep),
                         command("wakeup")

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/SleepCommand.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/SleepCommand.java
@@ -1,15 +1,26 @@
 package io.github.hello09x.fakeplayer.core.command.impl;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException;
 import dev.jorel.commandapi.executors.CommandArguments;
 import io.github.hello09x.devtools.core.utils.BlockUtils;
+import io.github.hello09x.fakeplayer.core.manager.FakeplayerAutosleepManager;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import static net.kyori.adventure.text.Component.translatable;
+
 @Singleton
 public class SleepCommand extends AbstractCommand {
+
+    private final FakeplayerAutosleepManager autosleepManager;
+
+    @Inject
+    public SleepCommand(FakeplayerAutosleepManager autosleepManager) {
+        this.autosleepManager = autosleepManager;
+    }
 
     /**
      * 睡觉
@@ -28,6 +39,31 @@ public class SleepCommand extends AbstractCommand {
         }
 
         fake.sleep(bed.getLocation(), false);
+    }
+
+    /**
+     * 睡觉一次
+     */
+    public void sleepOnce(@NotNull CommandSender sender, @NotNull CommandArguments args) throws WrapperCommandSyntaxException {
+        sleep(sender, args);
+    }
+
+    /**
+     * 自动睡觉
+     */
+    public void sleepAuto(@NotNull CommandSender sender, @NotNull CommandArguments args) throws WrapperCommandSyntaxException {
+        var fake = getFakeplayer(sender, args);
+        autosleepManager.setAutosleep(fake, true);
+        sender.sendMessage(translatable("fakeplayer.command.generic.success"));
+    }
+
+    /**
+     * 停止自动睡觉
+     */
+    public void sleepStop(@NotNull CommandSender sender, @NotNull CommandArguments args) throws WrapperCommandSyntaxException {
+        var fake = getFakeplayer(sender, args);
+        autosleepManager.setAutosleep(fake, false);
+        sender.sendMessage(translatable("fakeplayer.command.generic.success"));
     }
 
     /**

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/constant/MetadataKeys.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/constant/MetadataKeys.java
@@ -16,6 +16,8 @@ public interface MetadataKeys {
 
     String AUTOFISH = "fakeplayer:autofish";
 
+    String AUTOSLEEP = "fakeplayer:autosleep";
+
     static @Nullable Integer getSpawnedAt(@NotNull Player player) {
         var value = Iterables.getFirst(player.getMetadata(SPAWNED_AT), null);
         if (value == null) {

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/manager/FakeplayerAutosleepManager.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/manager/FakeplayerAutosleepManager.java
@@ -1,0 +1,113 @@
+package io.github.hello09x.fakeplayer.core.manager;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.github.hello09x.devtools.core.utils.BlockUtils;
+import io.github.hello09x.fakeplayer.core.Main;
+import io.github.hello09x.fakeplayer.core.constant.MetadataKeys;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.TimeSkipEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author fakeplayer
+ * Manages automatic sleeping for fake players
+ */
+@Singleton
+public class FakeplayerAutosleepManager implements Listener {
+
+    private final FakeplayerManager manager;
+
+    @Inject
+    public FakeplayerAutosleepManager(FakeplayerManager manager) {
+        this.manager = manager;
+    }
+
+    public boolean isAutosleep(@NotNull Player fake) {
+        return fake.hasMetadata(MetadataKeys.AUTOSLEEP);
+    }
+
+    public void setAutosleep(@NotNull Player target, boolean autosleep) {
+        if (!autosleep) {
+            target.removeMetadata(MetadataKeys.AUTOSLEEP, Main.getInstance());
+        } else {
+            target.setMetadata(MetadataKeys.AUTOSLEEP, new FixedMetadataValue(Main.getInstance(), true));
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+    public void onTimeSkip(@NotNull TimeSkipEvent event) {
+        if (event.getSkipReason() != TimeSkipEvent.SkipReason.NIGHT_SKIP) {
+            return;
+        }
+
+        // When time is skipped due to night, all players slept successfully
+        // We can use this to know when to re-enable auto sleep for next night
+    }
+
+    /**
+     * Checks periodically if it's night time and tries to sleep fakeplayers with autosleep enabled
+     */
+    public void checkAndSleep(@NotNull World world) {
+        long time = world.getTime();
+        // Night time is from 12542 to 23458 ticks
+        if (time < 12542 || time > 23458) {
+            return;
+        }
+
+        // Check all fakeplayers in this world with autosleep enabled
+        for (Player fake : manager.getAll()) {
+            if (!fake.getWorld().equals(world)) {
+                continue;
+            }
+
+            if (!isAutosleep(fake)) {
+                continue;
+            }
+
+            if (fake.isSleeping()) {
+                continue;
+            }
+
+            // Try to find a nearby bed and sleep
+            trySleep(fake);
+        }
+    }
+
+    private void trySleep(@NotNull Player fake) {
+        var bed = BlockUtils.getNearbyBlock(fake.getLocation(), 4, block -> {
+            if (!(block.getBlockData() instanceof Bed data)) {
+                return false;
+            }
+
+            return !data.isOccupied() && data.getPart() == Bed.Part.HEAD;
+        });
+
+        if (bed == null) {
+            return;
+        }
+
+        fake.sleep(bed.getLocation(), false);
+    }
+
+    /**
+     * Schedule a task to check for night time and auto sleep
+     */
+    public void startScheduler() {
+        Bukkit.getScheduler().runTaskTimer(Main.getInstance(), () -> {
+            for (World world : Bukkit.getWorlds()) {
+                if (world.getEnvironment() != World.Environment.NORMAL) {
+                    continue;
+                }
+                checkAndSleep(world);
+            }
+        }, 100L, 100L); // Check every 5 seconds (100 ticks)
+    }
+}


### PR DESCRIPTION
Add "once", "auto" and "stop" subcommands to the sleep command registration so users can explicitly sleep once, enable automatic sleeping, or disable it. Wire new handlers in SleepCommand:
- sleepOnce delegates to existing sleep behavior
- sleepAuto enables autosleep via FakeplayerAutosleepManager
- sleepStop disables autosleep via the manager Send a generic success message after toggling autosleep.

Introduce FakeplayerAutosleepManager to manage automatic sleeping state for fake players and register it as a listener. Provide methods to check and set autosleep metadata on fake players.

Perform dependency injection for the manager into SleepCommand and add necessary imports and translations. This enables persistent and controlled autosleep behavior for fake players.